### PR TITLE
Fix for scrapeIsChannelLive() for non english talking countries

### DIFF
--- a/src/YouTubeLiveStream.cpp
+++ b/src/YouTubeLiveStream.cpp
@@ -71,6 +71,8 @@ int YouTubeLiveStream::makeGetRequest(const char *command, const char *host, con
         client->println(cookie);
     } 
 
+    // Since we parse text, need to tell Youtube we want english
+    client->println(F("Accept-Language: en"));
     client->println(F("Cache-Control: no-cache"));
 
     //client->println();


### PR DESCRIPTION
Non sending a Acceppt-Language header.